### PR TITLE
Rename RSSlink to RSSLink

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -13,5 +13,5 @@
     <link rel="apple-touch-icon-precomposed" sizes="144x144" href="/apple-touch-icon-144-precomposed.png">
     <link rel="shortcut icon" href="/favicon.ico">
     <!-- RSS -->
-    <link href="{{ .RSSlink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
+    <link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
 </head>

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -15,7 +15,7 @@
                     <li><a href="{{ .url }}" {{ with .targetBlank }} target="_blank" {{ end }}>{{ .title }}</a></li>
                 {{ end }}
                 {{ if .Site.Params.useRSS }}
-                    <li><a href="{{ .RSSlink }}" type="application/rss+xml" target="_blank"><i class="fa fa-fw fa-rss"></i></a></li>
+                    <li><a href="{{ .RSSLink }}" type="application/rss+xml" target="_blank"><i class="fa fa-fw fa-rss"></i></a></li>
                 {{ end }}
             </ul>
         </div>


### PR DESCRIPTION
The former will be deprecated and eventually removed from Hugo.

Note: Currently both of them exist in Hugo, which is the reason for the cleanup.